### PR TITLE
Fix: build with Xcode 13 and drop old arch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,7 @@
 SHELL   := /usr/bin/env bash
 VERSION := 1.1.0
 
-TARGETS := armv7-apple-ios \
-           i386-apple-ios \
-           aarch64-apple-ios \
+TARGETS := aarch64-apple-ios \
            x86_64-apple-ios
 
 # pkg-config is invoked by libsodium-sys

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
 SHELL   := /usr/bin/env bash
-VERSION := 1.1.0
+VERSION := 1.2.0
 
 TARGETS := aarch64-apple-ios \
-           x86_64-apple-ios
+           x86_64-apple-ios \
+           aarch64-apple-ios-sim
 
 # pkg-config is invoked by libsodium-sys
 # cf. https://github.com/alexcrichton/pkg-config-rs/blob/master/src/lib.rs#L12

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A Rust cross-compiler (1.25.X or later) is needed that supports the following iO
 
   * aarch64-apple-ios
   * x86_64-apple-ios
+  * aarch64-apple-ios-sim
 
 It is recommended to use [rustup](https://github.com/rust-lang-nursery/rustup.rs) to manage the necessary
 compiler toolchains. Using rustup, the following commands will install the necessary binaries for
@@ -25,7 +26,8 @@ cross-compiling to above architectures:
 
     rustup target add aarch64-apple-ios
     rustup target add x86_64-apple-ios
-
+    rustup target add aarch64-apple-ios-sim
+    
 Alternatively, for instructions on how to build a compiler from source that supports
 all the necessary architectures, please refer to the [Rust Wiki](https://github.com/rust-lang/rust-wiki-backup/blob/master/Doc-building-for-ios.md).
 

--- a/README.md
+++ b/README.md
@@ -16,9 +16,6 @@ This project provides cross-compiled binaries of [cryptobox-c](https://github.co
 
 A Rust cross-compiler (1.25.X or later) is needed that supports the following iOS architectures:
 
-  * armv7-apple-ios
-  * armv7s-apple-ios
-  * i386-apple-ios
   * aarch64-apple-ios
   * x86_64-apple-ios
 
@@ -26,9 +23,6 @@ It is recommended to use [rustup](https://github.com/rust-lang-nursery/rustup.rs
 compiler toolchains. Using rustup, the following commands will install the necessary binaries for
 cross-compiling to above architectures:
 
-    rustup target add armv7-apple-ios
-    rustup target add armv7s-apple-ios
-    rustup target add i386-apple-ios
     rustup target add aarch64-apple-ios
     rustup target add x86_64-apple-ios
 

--- a/mk/cryptobox-src.mk
+++ b/mk/cryptobox-src.mk
@@ -1,6 +1,6 @@
 CRYPTOBOX_VERSION := v1.1.1
 CRYPTOBOX         := cryptobox-$(CRYPTOBOX_VERSION)
-CRYPTOBOX_GIT_URL := git@github.com:wireapp/cryptobox-c.git
+CRYPTOBOX_GIT_URL := https://github.com/wireapp/cryptobox-c
 CRYPTOBOX_SRC     := build/src/$(CRYPTOBOX)
 
 $(CRYPTOBOX_SRC):

--- a/mk/ios-full.sh
+++ b/mk/ios-full.sh
@@ -30,37 +30,36 @@
 #  Merge libs into final version for xcode import
 
 export PREFIX="$(pwd)/libsodium-ios"
-export IOS32_PREFIX="$PREFIX/tmp/ios32"
 export IOS64_PREFIX="$PREFIX/tmp/ios64"
-export SIMULATOR32_PREFIX="$PREFIX/tmp/simulator32"
 export SIMULATOR64_PREFIX="$PREFIX/tmp/simulator64"
+export SIMULATORARM64_PREFIX="$PREFIX/tmp/simulatorArm64"
 export XCODEDIR=$(xcode-select -p)
 
 xcode_major=$(xcodebuild -version|egrep '^Xcode '|cut -d' ' -f2|cut -d. -f1)
-if [ $xcode_major -ge 8 ]; then
-  export IOS_SIMULATOR_VERSION_MIN=${IOS_SIMULATOR_VERSION_MIN-"6.0.0"}
+if [ $xcode_major -ge 13 ]; then
+  export IOS_SIMULATOR_VERSION_MIN=${IOS_SIMULATOR_VERSION_MIN-"15.0.0"}
   export IOS_VERSION_MIN=${IOS_VERSION_MIN-"6.0.0"}
 else
   export IOS_SIMULATOR_VERSION_MIN=${IOS_SIMULATOR_VERSION_MIN-"5.1.1"}
   export IOS_VERSION_MIN=${IOS_VERSION_MIN-"5.1.1"}
 fi
 
-mkdir -p $SIMULATOR32_PREFIX $SIMULATOR64_PREFIX $IOS32_PREFIX $IOS64_PREFIX || exit 1
+mkdir -p $SIMULATOR64_PREFIX $IOS64_PREFIX || exit 1
 
 # Build for the simulator
 export BASEDIR="${XCODEDIR}/Platforms/iPhoneSimulator.platform/Developer"
 export PATH="${BASEDIR}/usr/bin:$BASEDIR/usr/sbin:$PATH"
 export SDK="${BASEDIR}/SDKs/iPhoneSimulator.sdk"
 
-## i386 simulator
-export CFLAGS="-O2 -arch i386 -isysroot ${SDK} -mios-simulator-version-min=${IOS_SIMULATOR_VERSION_MIN} -flto"
-export LDFLAGS="-arch i386 -isysroot ${SDK} -mios-simulator-version-min=${IOS_SIMULATOR_VERSION_MIN} -flto"
+## arm64 simulator
+export CFLAGS="-O2 -arch arm64 -isysroot ${SDK} -mios-simulator-version-min=${IOS_SIMULATOR_VERSION_MIN} -flto"
+export LDFLAGS="-arch arm64 -isysroot ${SDK} -mios-simulator-version-min=${IOS_SIMULATOR_VERSION_MIN} -flto"
 
 make distclean > /dev/null
 
-./configure --host=i686-apple-darwin10 \
+./configure --host=arm-apple-darwin20 \
             --disable-shared \
-            --prefix="$SIMULATOR32_PREFIX" || exit 1
+            --prefix="$SIMULATORARM64_PREFIX" || exit 1
 
 make -j3 install || exit 1
 
@@ -81,18 +80,6 @@ export BASEDIR="${XCODEDIR}/Platforms/iPhoneOS.platform/Developer"
 export PATH="${BASEDIR}/usr/bin:$BASEDIR/usr/sbin:$PATH"
 export SDK="${BASEDIR}/SDKs/iPhoneOS.sdk"
 
-## 32-bit iOS
-export CFLAGS="-O2 -mthumb -arch armv7 -isysroot ${SDK} -mios-version-min=${IOS_VERSION_MIN} -flto"
-export LDFLAGS="-mthumb -arch armv7 -isysroot ${SDK} -mios-version-min=${IOS_VERSION_MIN} -flto"
-
-make distclean > /dev/null
-
-./configure --host=arm-apple-darwin10 \
-            --disable-shared \
-            --prefix="$IOS32_PREFIX" || exit 1
-
-make -j3 install || exit 1
-
 ## 64-bit iOS
 export CFLAGS="-O2 -arch arm64 -isysroot ${SDK} -mios-version-min=${IOS_VERSION_MIN} -flto"
 export LDFLAGS="-arch arm64 -isysroot ${SDK} -mios-version-min=${IOS_VERSION_MIN} -flto"
@@ -109,12 +96,10 @@ make -j3 install || exit 1
 rm -fr -- "$PREFIX/include" "$PREFIX/libsodium.a" 2> /dev/null
 mkdir -p -- "$PREFIX"
 lipo -create \
-  "$SIMULATOR32_PREFIX/lib/libsodium.a" \
   "$SIMULATOR64_PREFIX/lib/libsodium.a" \
-  "$IOS32_PREFIX/lib/libsodium.a" \
+  "$SIMULATORARM64_PREFIX/lib/libsodium.a" \
   "$IOS64_PREFIX/lib/libsodium.a" \
   -output "$PREFIX/libsodium.a"
-mv -f -- "$IOS32_PREFIX/include" "$PREFIX/"
 
 echo
 echo "libsodium has been installed into $PREFIX"

--- a/mk/libsodium-src.mk
+++ b/mk/libsodium-src.mk
@@ -1,6 +1,7 @@
-LIBSODIUM_VERSION := 1.0.14
+LIBSODIUM_TAG	  := 1.0.18-RELEASE
+LIBSODIUM_VERSION := 1.0.18
 LIBSODIUM         := libsodium-$(LIBSODIUM_VERSION)
-LIBSODIUM_URL     := https://github.com/jedisct1/libsodium/releases/download/$(LIBSODIUM_VERSION)/$(LIBSODIUM).tar.gz
+LIBSODIUM_URL     := https://github.com/jedisct1/libsodium/releases/download/$(LIBSODIUM_TAG)/$(LIBSODIUM).tar.gz
 LIBSODIUM_SRC     := build/src/$(LIBSODIUM)
 
 $(LIBSODIUM_SRC):

--- a/mk/libsodium-src.mk
+++ b/mk/libsodium-src.mk
@@ -1,5 +1,4 @@
 LIBSODIUM_TAG	  := 1.0.18-RELEASE
-LIBSODIUM_VERSION := 1.0.18
 LIBSODIUM         := libsodium-$(LIBSODIUM_VERSION)
 LIBSODIUM_URL     := https://github.com/jedisct1/libsodium/releases/download/$(LIBSODIUM_TAG)/$(LIBSODIUM).tar.gz
 LIBSODIUM_SRC     := build/src/$(LIBSODIUM)


### PR DESCRIPTION
Remove unsupported armv7 and i386 arch
bump libsodium to 1.0.18